### PR TITLE
fix for error in popup file due to saveLink being null

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -6,6 +6,7 @@ chrome.tabs.getSelected(null,function(tab) { // null defaults to current window
   var url = tab.url;
 
   let saveLink = document.getElementById('save-link');
-  saveLink.href = "http://www.thiscodeworks.com/newlink?url="+url+"&pagetitle="+title;
-
+  if (saveLink !== null) {
+    saveLink.href = "http://www.thiscodeworks.com/newlink?url="+url+"&pagetitle="+title;
+  } 
 });


### PR DESCRIPTION
I have placed an if condition which checks whether saveLink is null or not. If it's not null then it will execute the next line otherwise it will do nothing. This is actually a fix for error which occurs when we load the extension in Chrome.

![image](https://user-images.githubusercontent.com/17095740/80855365-1118ba80-8c5a-11ea-839a-b1518aac00bb.png)
